### PR TITLE
Fixes issue that causes infinite loop when authenticating with sasl

### DIFF
--- a/hermes/src/main/java/org/jibble/pircbot/PircBot.java
+++ b/hermes/src/main/java/org/jibble/pircbot/PircBot.java
@@ -217,7 +217,7 @@ public abstract class PircBot implements ReplyConstants {
 
             while (authStringEncoded.length() >= 400) {
                 String toSend = authStringEncoded.substring(0, 400);
-                authString = authStringEncoded.substring(400);
+                authStringEncoded = authStringEncoded.substring(400);
 
                 OutputThread.sendRawLine(this, bwriter, "AUTHENTICATE " + toSend);
             }


### PR DESCRIPTION
Was unable to connect to my ZNC bouncer using SASL authentication and never got any indication from the app as to why it was failing. Looked into the code and this loop was going on endlessly because authStringEncoded was never getting any shorter.